### PR TITLE
Correct pip command to install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ git clone https://github.com/dell/idrac-ansible-module
 ```
 Install Ansible + required Python libraries:
 ```
-$ pip install requirements.txt
+$ pip install -r requirements.txt
 ```
 Copy module to default system location:
 ```


### PR DESCRIPTION
Correct pip command to install from requirements.txt file to use "-r" flag