### PR TITLE
Update the root URI to match the DMTF specification

### DIFF
--- a/library/redfish.py
+++ b/library/redfish.py
@@ -194,7 +194,7 @@ def main():
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_uri = "/redfish/v1"
+    rf_uri = "/redfish/v1/"
     rf_utils = RedfishUtils(creds, root_uri)
 
     # Organize by Categories / Commands


### PR DESCRIPTION
According to the DMTF Redfish specification section "6.2 Protocol version", page 23, Version 1.5.0 at: https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.5.0.pdf.

 The root URI for this version of the Redfish protocol shall be "/redfish/v1/"

Some implementations require the URI is terminated with a '/' as defined by the specification.