### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For more details on what commands are available in each category, refer to this 
 ## Requirements
 
   - Minimum iDRAC 7/8/9 FW 2.40.40.40
+  - Minimal ansible-playbook version 2.6.3
 
 ## Installation
 


### PR DESCRIPTION
With ansible-playbook v2.0.0.2 which comes by default under Ubuntu 16.04, I found that it misses few of modules which is required and hence user might encounter the below issue:

````
root@ubuntu:~# ansible-playbook --version
ansible-playbook 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
```
root@ubuntu:~/test/redfish-ansible-module/playbooks# ansible-playbook get_system_logs.yml
ERROR! no action detected in task

The error appears to have been in '/root/test/redfish-ansible-module/playbooks/get_system_logs.yml': line 12, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


  - name: Define output file
    ^ here

```

To fix this, one need to update ansible-playbook to 2.6.x version as shown below:

```
root@ubuntu:~# apt-add-repository ppa:ansible/ansible
```
apt-get update && apt-get install ansible
```

```
root@ubuntu:~/test/redfish-ansible-module/playbooks# ansible-playbook --version
ansible-playbook 2.6.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

```
root@ubuntu:~/test/redfish-ansible-module/playbooks# ansible-playbook get_system_inventory.yml

PLAY [System Inventory] ***************************************************************

TASK [Define output file] *************************************************************
included: /root/test/redfish-ansible-module/playbooks/create_output_file.yml for machine1, machine2

TASK [Define timestamp] ***************************************************************
ok: [machine1]

TASK [Define file to place results] ***************************************************
ok: [machine1]
ok: [machine2]
```

I suggest you to capture minimal requirement for ansible-playbook version for its smooth functionality.